### PR TITLE
Updating the script URL to the one currently appearing on the docs

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@
 }(this, function () {
   var config = null
   var directAccess = false
-  var gapiUrl = 'https://apis.google.com/js/api:client.js'
+  var gapiUrl = 'https://apis.google.com/js/platform.js'
 
   var gAuth = {
     install: function (Vue, options) {


### PR DESCRIPTION
The [Google Sign In docs](https://developers.google.com/identity/sign-in/web/sign-in) show a new URL that is applied on this commit, instead of using https://apis.google.com/js/api:client.js